### PR TITLE
Require login for entire app

### DIFF
--- a/app.py
+++ b/app.py
@@ -127,6 +127,9 @@ st.markdown(
     unsafe_allow_html=True
 )
 
+# Require user authentication before showing the app
+auth.require_login()
+
 
 # -------------------------
 # Sidebar: Logo & Navigation


### PR DESCRIPTION
## Summary
- ensure a login/register screen shows before accessing any page

## Testing
- `python -m py_compile app.py auth.py streaming.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_685a47e9eee48328b2526f1b64693144