### PR TITLE
Add FastAPI + Next.js skeleton

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY backend/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+COPY backend /app
+COPY utils.py streaming.py assets /app/
+EXPOSE 8000
+CMD ["uvicorn", "main:app", "--workers", "4", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,119 @@
+from fastapi import FastAPI, UploadFile, File, Form, WebSocket, WebSocketDisconnect
+from fastapi.middleware.cors import CORSMiddleware
+from sse_starlette.sse import EventSourceResponse
+from pydantic import BaseModel
+from typing import List, Dict, Any
+
+import utils
+from streaming import StreamHandler
+
+# LangChain imports (sample)
+from langchain.chains import ConversationChain
+from langchain_community.utilities.sql_database import SQLDatabase
+from langchain_community.agent_toolkits import create_sql_agent
+
+app = FastAPI(title="Chatbot API", openapi_url="/openapi.json", docs_url="/docs")
+
+# allow Next.js dev server
+origins = ["http://localhost:3000"]
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+class ChatRequest(BaseModel):
+    message: str
+    history: List[Dict[str, str]] | None = None
+    db_uri: str | None = None
+
+
+def stream_text(text: str):
+    async def event_generator():
+        for token in text.split():
+            yield {"event": "token", "data": token + " "}
+        yield {"event": "end", "data": ""}
+    return EventSourceResponse(event_generator())
+
+
+@app.post("/chat/basic")
+async def chat_basic(req: ChatRequest):
+    llm = utils.configure_llm()
+    chain = ConversationChain(llm=llm, verbose=False)
+    out = chain.invoke({"input": req.message})
+    return stream_text(out["response"])
+
+
+@app.post("/chat/sql")
+async def chat_sql(req: ChatRequest):
+    llm = utils.configure_llm()
+    db = SQLDatabase.from_uri(req.db_uri or "sqlite:///assets/movie.db")
+    agent = create_sql_agent(llm=llm, db=db, verbose=False)
+    out = agent.invoke({"input": req.message})
+    return stream_text(out["output"])
+
+
+@app.post("/chat/web")
+async def chat_web(req: ChatRequest):
+    from langchain_community.tools import DuckDuckGoSearchRun
+    search = DuckDuckGoSearchRun()
+    result = search.run(req.message)
+    return {"messages": [{"role": "assistant", "text": result}]}
+
+
+@app.post("/chat/advisory")
+async def chat_advisory(message: str = Form(...), file: UploadFile = File(...)):
+    from langchain_community.document_loaders import PyPDFLoader
+    from langchain.text_splitter import RecursiveCharacterTextSplitter
+    from langchain_community.vectorstores import DocArrayInMemorySearch
+    from langchain.chains import ConversationalRetrievalChain
+    from langchain.memory import ConversationBufferMemory
+
+    llm = utils.configure_llm()
+    path = f"/tmp/{file.filename}"
+    with open(path, "wb") as f:
+        f.write(await file.read())
+
+    loader = PyPDFLoader(path)
+    docs = loader.load()
+    splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=200)
+    chunks = splitter.split_documents(docs)
+    vectordb = DocArrayInMemorySearch.from_documents(chunks, utils.configure_embedding_model())
+    retriever = vectordb.as_retriever(search_type="mmr", search_kwargs={"k":2,"fetch_k":4})
+    memory = ConversationBufferMemory(return_messages=True, memory_key="chat_history")
+    chain = ConversationalRetrievalChain.from_llm(llm, retriever=retriever, memory=memory)
+    out = chain.invoke({"question": message})
+    return {"messages": [{"role": "assistant", "text": out["answer"]}]}
+
+
+@app.post("/chat/multi")
+async def chat_multi(req: ChatRequest):
+    # placeholder: combine sql + web search
+    llm = utils.configure_llm()
+    db = SQLDatabase.from_uri(req.db_uri or "sqlite:///assets/movie.db")
+    agent = create_sql_agent(llm=llm, db=db, verbose=False)
+    sql_out = agent.invoke({"input": req.message})
+    from langchain_community.tools import DuckDuckGoSearchRun
+    search = DuckDuckGoSearchRun()
+    web_out = search.run(req.message)
+    chain = ConversationChain(llm=llm, verbose=False)
+    final = chain.invoke({"input": f"SQL: {sql_out['output']}\nWeb: {web_out}"})
+    return stream_text(final["response"])
+
+
+@app.websocket("/ws/chat")
+async def websocket_chat(ws: WebSocket):
+    await ws.accept()
+    try:
+        while True:
+            data = await ws.receive_text()
+            llm = utils.configure_llm()
+            chain = ConversationChain(llm=llm, verbose=False)
+            out = chain.invoke({"input": data})
+            await ws.send_text(out["response"])
+    except WebSocketDisconnect:
+        pass
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,17 @@
+fastapi
+uvicorn[standard]
+sse-starlette
+langchain==0.3.13
+langchainhub==0.1.21
+langchain_community==0.3.13
+langchain_core==0.3.28
+langchain_openai==0.2.14
+openai==1.58.1
+requests
+SQLAlchemy==2.0.36
+validators
+fastembed==0.4.2
+pypdf==5.1.0
+duckduckgo_search==7.0.1
+aiohttp
+python-multipart

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY frontend/package.json ./
+COPY frontend/next.config.js ./
+COPY frontend/tailwind.config.js ./
+COPY frontend/postcss.config.js ./
+RUN npm install
+COPY frontend .
+RUN npm run build
+
+FROM node:20-alpine
+WORKDIR /app
+COPY --from=build /app .
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/frontend/components/ChatInput.tsx
+++ b/frontend/components/ChatInput.tsx
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+
+export default function ChatInput({ onSend }: { onSend(msg: string): void }) {
+  const [value, setValue] = useState('');
+  return (
+    <form
+      onSubmit={e => {
+        e.preventDefault();
+        if (!value.trim()) return;
+        onSend(value);
+        setValue('');
+      }}
+      className="p-4 flex space-x-2"
+    >
+      <input
+        className="flex-1 rounded border bg-zinc-900 text-white px-2"
+        value={value}
+        onChange={e => setValue(e.target.value)}
+        placeholder="Type a message"
+      />
+      <button type="submit" className="px-3 rounded bg-blue-600 text-white">
+        Send
+      </button>
+    </form>
+  );
+}

--- a/frontend/components/ChatWindow.tsx
+++ b/frontend/components/ChatWindow.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useRef } from 'react';
+
+export type Message = { role: 'user' | 'assistant'; text: string };
+
+export default function ChatWindow({ messages }: { messages: Message[] }) {
+  const bottomRef = useRef<HTMLDivElement>(null);
+  useEffect(() => bottomRef.current?.scrollIntoView({ behavior: 'smooth' }), [messages]);
+  return (
+    <div className="flex-1 overflow-y-auto p-4 space-y-2">
+      {messages.map((m, i) => (
+        <div
+          key={i}
+          className={`max-w-xl rounded px-3 py-2 ${m.role === 'user' ? 'bg-blue-600 text-white self-end ml-auto' : 'bg-zinc-800 text-white'}`}
+        >
+          {m.text}
+        </div>
+      ))}
+      <div ref={bottomRef} />
+    </div>
+  );
+}

--- a/frontend/components/FileUpload.tsx
+++ b/frontend/components/FileUpload.tsx
@@ -1,0 +1,11 @@
+export default function FileUpload({ onFiles }: { onFiles(files: FileList): void }) {
+  return (
+    <input
+      type="file"
+      accept="application/pdf"
+      multiple
+      onChange={e => e.target.files && onFiles(e.target.files)}
+      className="p-2"
+    />
+  );
+}

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+const links = [
+  { href: '/', label: 'Home' },
+  { href: '/basic', label: 'Basic' },
+  { href: '/sql', label: 'SQL' },
+  { href: '/web', label: 'Web' },
+  { href: '/advisory', label: 'Advisory' },
+  { href: '/multi', label: 'Multi' }
+];
+
+export default function Sidebar() {
+  const { pathname } = useRouter();
+  return (
+    <aside className="w-64 bg-zinc-950 text-white h-screen flex-shrink-0">
+      <nav className="p-4 space-y-2">
+        {links.map(l => (
+          <Link
+            key={l.href}
+            href={l.href}
+            className={`block px-2 py-1 rounded hover:bg-zinc-800 ${pathname === l.href ? 'bg-zinc-800' : ''}`}
+          >
+            {l.label}
+          </Link>
+        ))}
+      </nav>
+    </aside>
+  );
+}

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  images: { unoptimized: true }
+};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "search-markets-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.1.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "clsx": "^2.1.0",
+    "swr": "2.2.1"
+  },
+  "devDependencies": {
+    "autoprefixer": "10.4.15",
+    "postcss": "8.4.24",
+    "tailwindcss": "3.4.4",
+    "typescript": "5.4.3"
+  }
+}

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,0 +1,6 @@
+import '../styles/globals.css';
+import type { AppProps } from 'next/app';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/frontend/pages/advisory.tsx
+++ b/frontend/pages/advisory.tsx
@@ -1,0 +1,14 @@
+import Sidebar from '../components/Sidebar';
+import FileUpload from '../components/FileUpload';
+
+export default function Advisory() {
+  return (
+    <div className="flex h-screen text-white bg-black">
+      <Sidebar />
+      <main className="flex-1 p-4">
+        <FileUpload onFiles={() => {}} />
+        Advisory chat coming soon.
+      </main>
+    </div>
+  );
+}

--- a/frontend/pages/basic.tsx
+++ b/frontend/pages/basic.tsx
@@ -1,0 +1,10 @@
+import Sidebar from '../components/Sidebar';
+
+export default function Basic() {
+  return (
+    <div className="flex h-screen text-white bg-black">
+      <Sidebar />
+      <main className="flex-1 p-4">Basic chat coming soon.</main>
+    </div>
+  );
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,0 +1,10 @@
+import Sidebar from '../components/Sidebar';
+
+export default function Home() {
+  return (
+    <div className="flex h-screen text-white bg-black">
+      <Sidebar />
+      <main className="flex-1 p-4">Welcome</main>
+    </div>
+  );
+}

--- a/frontend/pages/multi.tsx
+++ b/frontend/pages/multi.tsx
@@ -1,0 +1,10 @@
+import Sidebar from '../components/Sidebar';
+
+export default function Multi() {
+  return (
+    <div className="flex h-screen text-white bg-black">
+      <Sidebar />
+      <main className="flex-1 p-4">Multi-source chat coming soon.</main>
+    </div>
+  );
+}

--- a/frontend/pages/sql.tsx
+++ b/frontend/pages/sql.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import Sidebar from '../components/Sidebar';
+import ChatWindow, { Message } from '../components/ChatWindow';
+import ChatInput from '../components/ChatInput';
+
+export default function SQL() {
+  const [messages, setMessages] = useState<Message[]>([]);
+
+  const send = async (text: string) => {
+    const user: Message = { role: 'user', text };
+    setMessages((m) => [...m, user]);
+    const res = await fetch('http://localhost:8000/chat/sql', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: text }),
+    });
+    if (!res.body) return;
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let answer = '';
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      if (value) answer += decoder.decode(value);
+    }
+    setMessages((m) => [...m, { role: 'assistant', text: answer }]);
+  };
+
+  return (
+    <div className="flex h-screen bg-black text-white">
+      <Sidebar />
+      <div className="flex flex-col flex-1">
+        <ChatWindow messages={messages} />
+        <ChatInput onSend={send} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/pages/web.tsx
+++ b/frontend/pages/web.tsx
@@ -1,0 +1,10 @@
+import Sidebar from '../components/Sidebar';
+
+export default function Web() {
+  return (
+    <div className="flex h-screen text-white bg-black">
+      <Sidebar />
+      <main className="flex-1 p-4">Web chat coming soon.</main>
+    </div>
+  );
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,10 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}'
+  ],
+  darkMode: 'class',
+  theme: { extend: {} },
+  plugins: []
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add FastAPI backend with SSE and websocket routes
- include Dockerfile and requirements for backend
- create Next.js frontend skeleton with sidebar navigation
- implement reusable React chat components
- provide SQL chat page streaming data from backend

## Testing
- `python -m py_compile backend/main.py utils.py streaming.py`
- `npx tsc -p frontend/tsconfig.json --noEmit` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6861f85ca4e88328b576c468ceea378c